### PR TITLE
Update fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -29,6 +29,5 @@ shared_scripts {
 dependencies {
     'vorp_core',
     'vorp_inventory',
-    'vorp_crafting',
-    'menuapi'
+    'vorp_crafting'
 }


### PR DESCRIPTION
menuapi is no longer required as the api is built into vorp premade.